### PR TITLE
Changed df_res.append to equivalent pd.concat function in the three files

### DIFF
--- a/Features_extraction_dataset1.py
+++ b/Features_extraction_dataset1.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import os
-import re
 import numpy as np
 
 df_res = pd.DataFrame(columns=['cycle', 'Voltages', 'rate', 'Tem', 'Capacity'])
@@ -30,8 +29,8 @@ for file in range(len(files)):
             if control[start + 13] != 0:
                 end = 12
         if control[start + end] == 0 and Ecell[start + end] > 4.0:
-            df_res = df_res.append({'cycle': i, 'Voltages': Ecell[start:start+14], 'rate': cr, 'Tem': Tem,
-                                    'Capacity': np.max(Q_dis)}, ignore_index=True)
+            df_res = pd.concat([df_res, pd.DataFrame.from_dict({'cycle': i, 'Voltages': Ecell[start:start+14], 'rate': cr, 'Tem': Tem,
+                                    'Capacity': np.max(Q_dis)})], ignore_index=True)
 
 # Save to excel file
 df_res.to_excel('Dataset_1_NCA_battery.xlsx', index=False)

--- a/Features_extraction_dataset2.py
+++ b/Features_extraction_dataset2.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import os
-import re
 import numpy as np
 
 
@@ -25,9 +24,8 @@ for file in range(len(files)):
             start = index[0][14]
             print(i)
         if control[start + 13] == 0:
-            df_res = df_res.append(
-                {'cycle': i, 'Voltages': Ecell[start:start + 14], 'rate': cr, 'Tem': Tem, 'Capacity': np.max(Q_dis)},
-                ignore_index=True)
+            df_res = pd.concat([df_res, pd.DataFrame.from_dict({'cycle': i, 'Voltages': Ecell[start:start + 14], 'rate': cr, 'Tem': Tem, 
+                                    'Capacity': np.max(Q_dis)})], ignore_index=True)
 
 # Save to excel file
 df_res.to_excel('Dataset_2_NCM_battery.xlsx', index=False)

--- a/Features_extraction_dataset3.py
+++ b/Features_extraction_dataset3.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import os
-import re
 import numpy as np
 
 
@@ -37,10 +36,8 @@ for file in range(len(files)):
             start = index[0][14]
             print(i)
         if control[start + 19] == 0:
-            df_res = df_res.append(
-                {'cycle': i, 'Voltages': Ecell[start:start + 59], 'C_rate': cr, 'D_rate': cr_d, 'Tem': Tem,
-                 'Capacity': np.max(Q_dis)}, ignore_index=True)
-
+            df_res = pd.concat([df_res, pd.DataFrame.from_dict({'cycle': i, 'Voltages': Ecell[start:start + 59], 'C_rate': cr, 'D_rate': cr_d, 'Tem': Tem,
+                                    'Capacity': np.max(Q_dis)})], ignore_index=True)
 # Save to excel file
 df_res.to_excel('Dataset_3_NCM_NCA_battery.xlsx', index=False)
 # Or save to csv file


### PR DESCRIPTION
In pandas, df.append is now deprecated and the original code raised errors when I tried to execute them. So I modified the lines with `df_res = df_res.append(...)` in all three dataset processor files to an equivalent `pd.concat([df_res, pd.DataFrame.from_dict({...})], ignore_index=True)` so it doesn't interrupt program flow. A byproduct is that pandas raises a warning but the program executes as expected:

`FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.`

Also, I'd suggest adding a requirements.txt file along with the repo as I forgot to install openpyxl and that gave an error in the code. 